### PR TITLE
Pin (beta) version of `clap` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 
 [dependencies]
 discv5 = { version = "0.1.0-alpha.7", features = ["libp2p"] }
-clap = "3.0.0-beta.1"
+clap = "=3.0.0-beta.1"
 futures = "0.3.5"
 tokio = { version = "0.2.21", features = ["full"] }
 libsecp256k1 = "0.3.5"


### PR DESCRIPTION
The API changes in `clap == 3.0.0-beta.2` and breaks the build, e.g. `cargo install $THIS_CLI_UTIL`