### PR TITLE
feat: enable setting listening address & port in request-enr

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,10 @@ Requests an ENR from a node
 Usage: discv5-cli request-enr --multiaddr <MULTIADDR>
 
 Options:
-  -m, --multiaddr <MULTIADDR>  The multiaddr of the node to request their ENR from
-  -h, --help                   Print help information
+  -m, --multiaddr <MULTIADDR>             The multiaddr of the node to request their ENR from
+  -h, --help                              Print help information
+  -l, --listen-address <LISTEN_ADDRESS>   Specifies the listening address of the server. [default: 0.0.0.0]
+  -p, --listen-port <LISTEN_PORT>         Specifies the listening UDP port of the server. [default: 9001]
 ```
 
 

--- a/src/request_enr/command.rs
+++ b/src/request_enr/command.rs
@@ -10,4 +10,20 @@ pub struct RequestEnr {
         help = "The multiaddr of the node to request their ENR from"
     )]
     pub multiaddr: String,
+    /// Specifies the listening address of the server.
+    #[clap(
+        short = 'l',
+        long = "listen-address",
+        help = "Specifies the IPv4 listening address of the server.",
+        default_value = "0.0.0.0"
+    )]
+    pub listen_address: String,
+    /// Specifies the listening UDP port of the server.
+    #[clap(
+        short = 'p',
+        long = "listen-port",
+        help = "Specifies the listening UDP port of the server.",
+        default_value = "9001"
+    )]
+    pub listen_port: u16,
 }

--- a/src/request_enr/mod.rs
+++ b/src/request_enr/mod.rs
@@ -3,6 +3,7 @@ use libp2p_core::Multiaddr;
 
 mod enr_ext;
 use enr_ext::EnrExt;
+use std::net::Ipv4Addr;
 
 /// The [clap] cli command arguments for the request-enr service.
 pub mod command;
@@ -17,8 +18,12 @@ pub async fn run(req: &RequestEnr) {
         .expect("Invalid Multiaddr provided");
 
     // Set up a server to receive the response
-    let listen_address = std::net::Ipv4Addr::UNSPECIFIED;
-    let listen_port = 9001;
+    let listen_address = req
+        .listen_address
+        .parse::<Ipv4Addr>()
+        .expect("Invalid listening address");
+
+    let listen_port = req.listen_port;
     let listen_config = ListenConfig::from_ip(listen_address.into(), listen_port);
     let enr_key = enr::CombinedKey::generate_secp256k1();
 


### PR DESCRIPTION
Currently the server port used in ``discv5-cli request-enr ``is hardcoded to 9001.

This PR adds support to allow configuring the address & port, similar to how it's used in the ``discv5-cli server`` command.

Defaults to ``0.0.0.0:9001`` if not set.

##### Usage:
```
discv5-cli request-enr -p <listening port> -l <listening address> -m <multiaddr>
```